### PR TITLE
Add partial support of fixed-point numbers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [features]
 default = [ "std" ]
 std = [ ]
-partial_fixed_point_support = [ "fixed", "fixed-sqrt", "fixed-trig" ]
+partial_fixed_point_support = [ "fixed", "cordic" ]
 
 [dependencies]
 num-traits  = { version = "0.2.11", default-features = false, features = ["libm"] }
@@ -23,6 +23,6 @@ num-complex = { version = "0.2", default-features = false }
 packed_simd = { version = "0.3", optional = true }
 wide        = { version = "0.4", optional = true }
 fixed       = { version = "0.5", optional = true }
-fixed-sqrt  = { version = "0.2", optional = true }
-fixed-trig  = { version = "0.1", optional = true, path = "../fixed-trig/fixed-trig" }
+cordic      = { version = "0.1", optional = true }
 paste       = "0.1"
+rand        = { version = "0.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [features]
 default = [ "std" ]
 std = [ ]
-partial_fixed_point_support = [ "fixed" ]
+partial_fixed_point_support = [ "fixed", "fixed-sqrt", "fixed-trig" ]
 
 [dependencies]
 num-traits  = { version = "0.2.11", default-features = false, features = ["libm"] }
@@ -23,4 +23,6 @@ num-complex = { version = "0.2", default-features = false }
 packed_simd = { version = "0.3", optional = true }
 wide        = { version = "0.4", optional = true }
 fixed       = { version = "0.5", optional = true }
+fixed-sqrt  = { version = "0.2", optional = true }
+fixed-trig  = { version = "0.1", optional = true, path = "../fixed-trig/fixed-trig" }
 paste       = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [features]
 default = [ "std" ]
 std = [ ]
+partial_fixed_point_support = [ "fixed" ]
 
 [dependencies]
 num-traits  = { version = "0.2.11", default-features = false, features = ["libm"] }
@@ -21,4 +22,5 @@ decimal     = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.2", default-features = false }
 packed_simd = { version = "0.3", optional = true }
 wide        = { version = "0.4", optional = true }
+fixed       = { version = "0.5", optional = true }
 paste       = "0.1"

--- a/src/scalar/fixed.rs
+++ b/src/scalar/fixed.rs
@@ -1,0 +1,799 @@
+//! Implementation of traits form fixed-point numbers.
+use crate::scalar::{ComplexField, Field, RealField, SubsetOf, SupersetOf};
+use crate::simd::{PrimitiveSimdValue, SimdValue};
+use fixed::types::extra::{LeEqU128, LeEqU16, LeEqU32, LeEqU64, LeEqU8};
+use num::{Bounded, FromPrimitive, Num, One, Signed, Zero};
+use std::cmp::Ordering;
+use std::ops::{
+    Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
+};
+
+macro_rules! impl_fixed_type(
+    ($($FixedI: ident, $LeEqDim: ident;)*) => {$(
+        #[derive(Copy, Clone)]
+        /// Signed fixed-point number with a generic number of bits for the fractional part.
+        pub struct $FixedI<Fract: $LeEqDim>(pub fixed::$FixedI<Fract>);
+
+        impl<Fract: $LeEqDim> PartialEq for $FixedI<Fract> {
+            #[inline(always)]
+            fn eq(&self, other: &Self) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        impl<Fract: $LeEqDim> Eq for $FixedI<Fract> {}
+
+        impl<Fract: $LeEqDim> PartialOrd for $FixedI<Fract> {
+            #[inline(always)]
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                self.0.partial_cmp(&other.0)
+            }
+        }
+
+        impl<Fract: $LeEqDim> PrimitiveSimdValue for $FixedI<Fract> {}
+        impl<Fract: $LeEqDim> SimdValue for $FixedI<Fract> {
+            type Element = Self;
+            type SimdBool = bool;
+
+            #[inline(always)]
+            fn lanes() -> usize {
+                1
+            }
+
+            #[inline(always)]
+            fn splat(val: Self::Element) -> Self {
+                val
+            }
+
+            #[inline(always)]
+            fn extract(&self, _: usize) -> Self::Element {
+                *self
+            }
+
+            #[inline(always)]
+            unsafe fn extract_unchecked(&self, _: usize) -> Self::Element {
+                *self
+            }
+
+            #[inline(always)]
+            fn replace(&mut self, _: usize, val: Self::Element) {
+                *self = val
+            }
+
+            #[inline(always)]
+            unsafe fn replace_unchecked(&mut self, _: usize, val: Self::Element) {
+                *self = val
+            }
+
+            #[inline(always)]
+            fn select(self, cond: Self::SimdBool, other: Self) -> Self {
+                if cond {
+                    self
+                } else {
+                    other
+                }
+            }
+        }
+
+        impl<Fract: $LeEqDim> Mul for $FixedI<Fract> {
+            type Output = Self;
+            #[inline(always)]
+            fn mul(self, rhs: Self) -> Self {
+                Self(self.0 * rhs.0)
+            }
+        }
+
+        impl<Fract: $LeEqDim> Div for $FixedI<Fract> {
+            type Output = Self;
+            #[inline(always)]
+            fn div(self, rhs: Self) -> Self {
+                Self(self.0 / rhs.0)
+            }
+        }
+
+        impl<Fract: $LeEqDim> Rem for $FixedI<Fract> {
+            type Output = Self;
+            #[inline(always)]
+            fn rem(self, rhs: Self) -> Self {
+                Self(self.0 % rhs.0)
+            }
+        }
+
+        impl<Fract: $LeEqDim> Add for $FixedI<Fract> {
+            type Output = Self;
+            #[inline(always)]
+            fn add(self, rhs: Self) -> Self {
+                Self(self.0 + rhs.0)
+            }
+        }
+
+        impl<Fract: $LeEqDim> Sub for $FixedI<Fract> {
+            type Output = Self;
+            #[inline(always)]
+            fn sub(self, rhs: Self) -> Self {
+                Self(self.0 - rhs.0)
+            }
+        }
+
+        impl<Fract: $LeEqDim> Neg for $FixedI<Fract> {
+            type Output = Self;
+            #[inline(always)]
+            fn neg(self) -> Self {
+                Self(-self.0)
+            }
+        }
+
+        impl<Fract: $LeEqDim> MulAssign for $FixedI<Fract> {
+            #[inline(always)]
+            fn mul_assign(&mut self, rhs: Self) {
+                self.0 *= rhs.0
+            }
+        }
+
+        impl<Fract: $LeEqDim> DivAssign for $FixedI<Fract> {
+            #[inline(always)]
+            fn div_assign(&mut self, rhs: Self) {
+                self.0 /= rhs.0
+            }
+        }
+
+        impl<Fract: $LeEqDim> RemAssign for $FixedI<Fract> {
+            #[inline(always)]
+            fn rem_assign(&mut self, rhs: Self) {
+                self.0 %= rhs.0
+            }
+        }
+
+        impl<Fract: $LeEqDim> AddAssign for $FixedI<Fract> {
+            #[inline(always)]
+            fn add_assign(&mut self, rhs: Self) {
+                self.0 += rhs.0
+            }
+        }
+
+        impl<Fract: $LeEqDim> SubAssign for $FixedI<Fract> {
+            #[inline(always)]
+            fn sub_assign(&mut self, rhs: Self) {
+                self.0 -= rhs.0
+            }
+        }
+
+        impl<Fract: $LeEqDim> Zero for $FixedI<Fract> {
+            #[inline(always)]
+            fn zero() -> Self {
+                Self(fixed::$FixedI::from_num(0))
+            }
+
+            #[inline(always)]
+            fn is_zero(&self) -> bool {
+                self.0 == Self::zero().0
+            }
+        }
+
+        impl<Fract: $LeEqDim> One for $FixedI<Fract> {
+            #[inline(always)]
+            fn one() -> Self {
+                Self(fixed::$FixedI::from_num(1))
+            }
+        }
+
+        impl<Fract: $LeEqDim> Num for $FixedI<Fract> {
+            type FromStrRadixErr = ();
+            fn from_str_radix(_str: &str, _radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+                unimplemented!()
+            }
+        }
+
+        impl<Fract: $LeEqDim> Field for $FixedI<Fract> {}
+
+        impl<Fract: $LeEqDim> SubsetOf<$FixedI<Fract>> for f64 {
+            #[inline]
+            fn to_superset(&self) -> $FixedI<Fract> {
+                $FixedI(fixed::$FixedI::from_num(*self))
+            }
+
+            #[inline]
+            fn from_superset(element: &$FixedI<Fract>) -> Option<Self> {
+                Some(Self::from_superset_unchecked(element))
+            }
+
+            #[inline]
+            fn from_superset_unchecked(element: &$FixedI<Fract>) -> Self {
+                element.0.to_num::<f64>()
+            }
+
+            #[inline]
+            fn is_in_subset(_: &$FixedI<Fract>) -> bool {
+                true
+            }
+        }
+
+        impl<Fract: $LeEqDim> SubsetOf<$FixedI<Fract>> for $FixedI<Fract> {
+            #[inline]
+            fn to_superset(&self) -> $FixedI<Fract> {
+                *self
+            }
+
+            #[inline]
+            fn from_superset(element: &$FixedI<Fract>) -> Option<Self> {
+                Some(*element)
+            }
+
+            #[inline]
+            fn from_superset_unchecked(element: &$FixedI<Fract>) -> Self {
+                *element
+            }
+
+            #[inline]
+            fn is_in_subset(_: &$FixedI<Fract>) -> bool {
+                true
+            }
+        }
+
+        impl<Fract: $LeEqDim> approx::AbsDiffEq for $FixedI<Fract> {
+            type Epsilon = Self;
+            fn default_epsilon() -> Self::Epsilon {
+                Self(fixed::$FixedI::from_bits(0b01))
+            }
+
+            fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+                // This is the impl used in the approx crate.
+                if self > other {
+                    (*self - *other) <= epsilon
+                } else {
+                    (*other - *self) <= epsilon
+                }
+            }
+        }
+
+        impl<Fract: $LeEqDim> approx::RelativeEq for $FixedI<Fract> {
+            fn default_max_relative() -> Self::Epsilon {
+                use approx::AbsDiffEq;
+                Self::default_epsilon()
+            }
+
+            fn relative_eq(
+                &self,
+                other: &Self,
+                epsilon: Self::Epsilon,
+                max_relative: Self::Epsilon,
+            ) -> bool
+            {
+                // This is the impl used in the approx crate.
+                let abs_diff = (*self - *other).abs();
+
+                if abs_diff <= epsilon {
+                    return true;
+                }
+
+                let abs_self = self.abs();
+                let abs_other = other.abs();
+
+                let largest = if abs_other > abs_self {
+                    abs_other
+                } else {
+                    abs_self
+                };
+
+                abs_diff <= largest * max_relative
+            }
+        }
+
+        impl<Fract: $LeEqDim> approx::UlpsEq for $FixedI<Fract> {
+            fn default_max_ulps() -> u32 {
+                4
+            }
+
+            fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
+                println!("XXX Invalid fixed-point ulps_eq implementation.");
+                self.0.to_num::<f64>().ulps_eq(&other.0.to_num::<f64>(), epsilon.0.to_num::<f64>(), max_ulps)
+            }
+        }
+
+        impl<Fract: $LeEqDim> std::fmt::Debug for $FixedI<Fract> {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl<Fract: $LeEqDim> std::fmt::Display for $FixedI<Fract> {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl<Fract: $LeEqDim> Bounded for $FixedI<Fract> {
+            #[inline]
+            fn min_value() -> Self {
+                Self(fixed::$FixedI::MIN)
+            }
+
+            #[inline]
+            fn max_value() -> Self {
+                Self(fixed::$FixedI::MAX)
+            }
+        }
+
+        impl<Fract: $LeEqDim> FromPrimitive for $FixedI<Fract> {
+            fn from_i64(n: i64) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_u64(n: u64) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_isize(n: isize) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_i8(n: i8) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_i16(n: i16) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_i32(n: i32) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_usize(n: usize) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_u8(n: u8) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_u16(n: u16) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_u32(n: u32) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_f32(n: f32) -> Option<Self> {
+                unimplemented!()
+            }
+            fn from_f64(n: f64) -> Option<Self> {
+                unimplemented!()
+            }
+        }
+
+        impl<Fract: $LeEqDim> Signed for $FixedI<Fract> {
+            fn abs(&self) -> Self {
+                Self(self.0.abs())
+            }
+
+            fn abs_sub(&self, other: &Self) -> Self {
+                unimplemented!()
+            }
+
+            fn signum(&self) -> Self {
+                Self(self.0.signum())
+            }
+
+            fn is_positive(&self) -> bool {
+                println!("XXX Invalid fixed-point is_positive implementation.");
+                self.0.to_num::<f64>().is_positive()
+            }
+
+            fn is_negative(&self) -> bool {
+                println!("XXX Invalid fixed-point is_negative implementation.");
+                self.0.to_num::<f64>().is_negative()
+            }
+        }
+
+        impl<Fract: $LeEqDim + Send + Sync + 'static> ComplexField for $FixedI<Fract> {
+            type RealField = Self;
+
+            #[inline]
+            fn from_real(re: Self::RealField) -> Self {
+                re
+            }
+
+            #[inline]
+            fn real(self) -> Self::RealField {
+                self
+            }
+
+            #[inline]
+            fn imaginary(self) -> Self::RealField {
+                Self::zero()
+            }
+
+            #[inline]
+            fn norm1(self) -> Self::RealField {
+                self.abs()
+            }
+
+            #[inline]
+            fn modulus(self) -> Self::RealField {
+                self.abs()
+            }
+
+            #[inline]
+            fn modulus_squared(self) -> Self::RealField {
+                self * self
+            }
+
+            #[inline]
+            fn argument(self) -> Self::RealField {
+                if self >= Self::zero() {
+                    Self::zero()
+                } else {
+                    Self::pi()
+                }
+            }
+
+            #[inline]
+            fn to_exp(self) -> (Self, Self) {
+                if self >= Self::zero() {
+                    (self, Self::one())
+                } else {
+                    (-self, -Self::one())
+                }
+            }
+
+            #[inline]
+            fn recip(self) -> Self {
+                Self::one() / self
+            }
+
+            #[inline]
+            fn conjugate(self) -> Self {
+                self
+            }
+
+            #[inline]
+            fn scale(self, factor: Self::RealField) -> Self {
+                self * factor
+            }
+
+            #[inline]
+            fn unscale(self, factor: Self::RealField) -> Self {
+                self / factor
+            }
+
+            #[inline]
+            fn floor(self) -> Self {
+                Self(self.0.floor())
+            }
+
+            #[inline]
+            fn ceil(self) -> Self {
+                Self(self.0.ceil())
+            }
+
+            #[inline]
+            fn round(self) -> Self {
+                Self(self.0.round())
+            }
+
+            #[inline]
+            fn trunc(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn fract(self) -> Self {
+                Self(self.0.frac())
+            }
+
+            #[inline]
+            fn abs(self) -> Self {
+                Self(self.0.abs())
+            }
+
+            #[inline]
+            fn signum(self) -> Self {
+                Self(self.0.signum())
+            }
+
+            #[inline]
+            fn mul_add(self, a: Self, b: Self) -> Self {
+                self * a + b
+            }
+
+            #[cfg(feature = "std")]
+            #[inline]
+            fn powi(self, n: i32) -> Self {
+                unimplemented!()
+            }
+
+            #[cfg(not(feature = "std"))]
+            #[inline]
+            fn powi(self, n: i32) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn powf(self, n: Self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn powc(self, n: Self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn sqrt(self) -> Self {
+                println!("XXX Invalid fixed-point sqrt implementation.");
+                self.0.to_num::<f64>().sqrt().to_superset()
+            }
+
+            #[inline]
+            fn try_sqrt(self) -> Option<Self> {
+                if self >= Self::zero() {
+                    Some(self.sqrt())
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn exp(self) -> Self {
+                println!("XXX Invalid fixed-point exp implementation.");
+                self.0.to_num::<f64>().exp().to_superset()
+            }
+
+            #[inline]
+            fn exp2(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn exp_m1(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn ln_1p(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn ln(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn log(self, base: Self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn log2(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn log10(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn cbrt(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn hypot(self, other: Self) -> Self::RealField {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn sin(self) -> Self {
+                println!("XXX Invalid fixed-point sin implementation.");
+                self.0.to_num::<f64>().sin().to_superset()
+            }
+
+            #[inline]
+            fn cos(self) -> Self {
+                println!("XXX Invalid fixed-point cos implementation.");
+                self.0.to_num::<f64>().cos().to_superset()
+            }
+
+            #[inline]
+            fn tan(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn asin(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn acos(self) -> Self {
+                println!("XXX Invalid fixed-point acos implementation.");
+                self.0.to_num::<f64>().acos().to_superset()
+            }
+
+            #[inline]
+            fn atan(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn sin_cos(self) -> (Self, Self) {
+                (self.sin(), self.cos())
+            }
+
+            #[inline]
+            fn sinh(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn cosh(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn tanh(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn asinh(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn acosh(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn atanh(self) -> Self {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn is_finite(&self) -> bool {
+                unimplemented!()
+            }
+        }
+
+        impl<Fract: $LeEqDim + Send + Sync + 'static> RealField for $FixedI<Fract> {
+            #[inline]
+            fn is_sign_positive(self) -> bool {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn is_sign_negative(self) -> bool {
+                unimplemented!()
+            }
+
+            #[inline]
+            fn max(self, other: Self) -> Self {
+                if self >= other {
+                    self
+                } else {
+                    other
+                }
+            }
+
+            #[inline]
+            fn min(self, other: Self) -> Self {
+                if self < other {
+                    self
+                } else {
+                    other
+                }
+            }
+
+            #[inline]
+            fn clamp(self, min: Self, max: Self) -> Self {
+                if self < min {
+                    min
+                } else if self > max {
+                    max
+                } else {
+                    self
+                }
+            }
+
+            #[inline]
+            fn atan2(self, other: Self) -> Self {
+                println!("XXX Invalid fixed-point atan2 implementation.");
+                self.0.to_num::<f64>().atan2(other.0.to_num::<f64>()).to_superset()
+            }
+
+            /// Archimedes' constant.
+            #[inline]
+            fn pi() -> Self {
+                println!("XXX Invalid fixed-point pi implementation.");
+                f64::pi().to_superset()
+            }
+
+            /// 2.0 * pi.
+            #[inline]
+            fn two_pi() -> Self {
+                unimplemented!()
+            }
+
+            /// pi / 2.0.
+            #[inline]
+            fn frac_pi_2() -> Self {
+                unimplemented!()
+            }
+
+            /// pi / 3.0.
+            #[inline]
+            fn frac_pi_3() -> Self {
+                unimplemented!()
+            }
+
+            /// pi / 4.0.
+            #[inline]
+            fn frac_pi_4() -> Self {
+                unimplemented!()
+            }
+
+            /// pi / 6.0.
+            #[inline]
+            fn frac_pi_6() -> Self {
+                unimplemented!()
+            }
+
+            /// pi / 8.0.
+            #[inline]
+            fn frac_pi_8() -> Self {
+                unimplemented!()
+            }
+
+            /// 1.0 / pi.
+            #[inline]
+            fn frac_1_pi() -> Self {
+                unimplemented!()
+            }
+
+            /// 2.0 / pi.
+            #[inline]
+            fn frac_2_pi() -> Self {
+                unimplemented!()
+            }
+
+            /// 2.0 / sqrt(pi).
+            #[inline]
+            fn frac_2_sqrt_pi() -> Self {
+                unimplemented!()
+            }
+
+            /// Euler's number.
+            #[inline]
+            fn e() -> Self {
+                unimplemented!()
+            }
+
+            /// log2(e).
+            #[inline]
+            fn log2_e() -> Self {
+                unimplemented!()
+            }
+
+            /// log10(e).
+            #[inline]
+            fn log10_e() -> Self {
+                unimplemented!()
+            }
+
+            /// ln(2.0).
+            #[inline]
+            fn ln_2() -> Self {
+                unimplemented!()
+            }
+
+            /// ln(10.0).
+            #[inline]
+            fn ln_10() -> Self {
+                unimplemented!()
+            }
+        }
+    )*}
+);
+
+impl_fixed_type!(
+    FixedI8, LeEqU8;
+    FixedI16, LeEqU16;
+    FixedI32, LeEqU32;
+    FixedI64, LeEqU64;
+    FixedI128, LeEqU128;
+);

--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -804,3 +804,6 @@ impl_fixed_type!(
 );
 
 pub type FixedI16F16 = FixedI32<fixed::types::extra::U16>;
+pub type FixedI32F32 = FixedI64<fixed::types::extra::U32>;
+pub type FixedI40F24 = FixedI64<fixed::types::extra::U24>;
+pub type FixedI48F16 = FixedI64<fixed::types::extra::U16>;

--- a/src/scalar/fixed_impl.rs
+++ b/src/scalar/fixed_impl.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 //! Implementation of traits form fixed-point numbers.
 use crate::scalar::{ComplexField, Field, RealField, SubsetOf, SupersetOf};
 use crate::simd::{PrimitiveSimdValue, SimdValue};
@@ -800,3 +802,5 @@ impl_fixed_type!(
     FixedI32, LeEqU32, U32, U30, U29;
     FixedI64, LeEqU64, U64, U62, U61;
 );
+
+pub type FixedI16F16 = FixedI32<fixed::types::extra::U16>;

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -2,6 +2,8 @@
 
 pub use self::complex::ComplexField;
 pub use self::field::{ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, Field};
+#[cfg(feature = "partial_fixed_point_support")]
+pub use self::fixed::{FixedI128, FixedI16, FixedI32, FixedI64, FixedI8};
 pub use self::real::RealField;
 pub use self::subset::{SubsetOf, SupersetOf};
 
@@ -9,4 +11,6 @@ mod real;
 #[macro_use]
 mod complex;
 mod field;
+#[cfg(feature = "partial_fixed_point_support")]
+mod fixed;
 mod subset;

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -3,7 +3,7 @@
 pub use self::complex::ComplexField;
 pub use self::field::{ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, Field};
 #[cfg(feature = "partial_fixed_point_support")]
-pub use self::fixed::{FixedI128, FixedI16, FixedI32, FixedI64, FixedI8};
+pub use self::fixed::{FixedI16, FixedI32, FixedI64, FixedI8};
 pub use self::real::RealField;
 pub use self::subset::{SubsetOf, SupersetOf};
 

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -3,7 +3,7 @@
 pub use self::complex::ComplexField;
 pub use self::field::{ClosedAdd, ClosedDiv, ClosedMul, ClosedNeg, ClosedSub, Field};
 #[cfg(feature = "partial_fixed_point_support")]
-pub use self::fixed::{FixedI16, FixedI32, FixedI64, FixedI8};
+pub use self::fixed_impl::*;
 pub use self::real::RealField;
 pub use self::subset::{SubsetOf, SupersetOf};
 
@@ -12,5 +12,5 @@ mod real;
 mod complex;
 mod field;
 #[cfg(feature = "partial_fixed_point_support")]
-mod fixed;
+mod fixed_impl;
 mod subset;

--- a/src/scalar/subset.rs
+++ b/src/scalar/subset.rs
@@ -45,8 +45,8 @@ pub trait SubsetOf<T>: Sized {
 }
 
 /// Nested sets and conversions between them. Useful to work with substructures. It is preferable
-/// to implement the `SupersetOf` trait instead of `SubsetOf` whenever possible (because
-/// `SupersetOf` is automatically implemented whenever `SubsetOf` is.
+/// to implement the `SubsetOf` trait instead of `SupersetOf` whenever possible (because
+/// `SupersetOf` is automatically implemented whenever `SubsetOf` is).
 ///
 /// The notion of "nested sets" is very broad and applies to what the types are _supposed to
 /// represent_, independently from their actual implementation details and limitations. For


### PR DESCRIPTION
This add partial support of fixed-points numbers. Here "partial" means that fixed-point numbers implement all the `scalar` traits (including `RealField`) but a lot of their functions are just `unimplemented!()`. Among the special functions, only non-hyperbolic trigonometric functions, sqrt, and exp, are implemented.

In order to enable fixed-point supports, it is necessary to enable the `partial_fixed_point_support` feature of simba. The supported fixed-point types are exported in the `simba::scalar` module (e.g. `simba::scalar::FixedI40F24` for a 64-bits fixed-point numbers with a 24-bits decimal part.