### PR TITLE
Fix compilation bug by updating "fixed" dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ decimal     = { version = "2.0", default-features = false, optional = true }
 num-complex = { version = "0.2", default-features = false }
 packed_simd = { version = "0.3", optional = true }
 wide        = { version = "0.4", optional = true }
-fixed       = { version = "0.5", optional = true }
+fixed       = { version = "1", optional = true }
 cordic      = { version = "0.1", optional = true }
 paste       = "0.1"
 rand        = { version = "0.7", optional = true }


### PR DESCRIPTION
For the `partial_fixed_point_support` feature, the actual `simba` version "0.1.4" depends on : 
- `cordic` "0.1" 
 - `fixed` "0.5"

But the last `cordic` version "0.1.4" depends on : 
- `fixed` "1"

This cause compilation problem when this feature is activated.

this behavior happens with `simba` "0.1.3" too.